### PR TITLE
fixed windows ENOENT error on npm start

### DIFF
--- a/develop.js
+++ b/develop.js
@@ -17,12 +17,15 @@ var processes = [
 ];
 
 processes.forEach(function(proc){
+  if(process.platform === 'win32') {
+    proc.command += '.cmd';
+  }
   var single = spawn(proc.command, proc.args, {cwd: proc.cwd});
   single.stdout.on('data', function(data){
-    process.stdout.write('[' + proc.args[1] + ']: ' + data.toString('utf8'));
+    process.stdout.write(data.toString('utf8'));
   });
   single.stderr.on('data', function(data){
-    process.stdout.write('[' + proc.args[1] + ']: ' +data.toString('utf8'));
+    process.stdout.write(data.toString('utf8'));
   });
   single.stderr.on('close', function(code){
     console.log('Process "' + proc.command + '" exited with code: ' + code);


### PR DESCRIPTION
On windows, npm is run as npm.cmd in the command line.
